### PR TITLE
updated deps, fixed new expectations for num_customers metric

### DIFF
--- a/models/retail/marts/marts.yml
+++ b/models/retail/marts/marts.yml
@@ -34,10 +34,14 @@ metrics:
     label: Number of Customers
     tags: 
       - retail
-    model: ref('dim_customers')
+    model: ref('fct_order_items')
     description: "The number of customers"
 
-    type: count
+    calculation_method: count_distinct
+    expression: customer_key
+
+    timestamp: order_date
+    time_grains: [day, week, month, quarter, year]
 
     dimensions:
       - market_segment

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,8 @@
 packages:
   - package: dbt-labs/dbt_utils
-    version: 0.8.6
+    version: 0.9.2
+
+  - package: dbt-labs/metrics
+    version: 1.3.0-rc1
+
+    


### PR DESCRIPTION
- upgrade to dbt v1.3
- metric changes to pull from fct_order_items to get customership over time (dim_customers didn't have any time column -- this may be worth revisiting in the future and correcting)