### PR TITLE
Cleanup + generate_schema_name fixes

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -27,4 +27,4 @@ models:
         - daily
 
 
-on-run-end: "{{ drop_ci_schemas(schemas, dry_run=False, target_name_override='ci') }}"
+on-run-end: "{{ drop_ci_schemas(schemas, dry_run=False) }}"

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -27,4 +27,4 @@ models:
         - daily
 
 
-        
+on-run-end: "{{ drop_ci_schemas(schemas, dry_run=False, target_name_override='ci') }}"

--- a/macros/config/generate_schema_name.sql
+++ b/macros/config/generate_schema_name.sql
@@ -1,11 +1,8 @@
 {%- macro generate_schema_name(custom_schema_name, node) -%}
     {% set default_schema = env_var('DBT_DEFAULT_SCHEMA') %}
 
-    {% if target.name == 'default' %}
-        {{target.schema}}__{{default_schema}}
-
-    {% elif target.name == 'ci' %}
-        {{target.schema}}__{{default_schema}}
+    {% if target.name == 'default' or 'ci' in target.name.lower() or 'test' in target.name.lower() %}
+        {{target.schema}}
 
     {% elif 'production' in target.name %}
         {{ custom_schema_name if custom_schema_name else default_schema }}

--- a/macros/utils/clean_workspace.sql
+++ b/macros/utils/clean_workspace.sql
@@ -1,0 +1,65 @@
+{# clean_workspace
+
+This macro drops all the schemas within a database to "clean" the workspace.
+
+The schemas to drop will be those that match the schema_like (if provided) AND do not match the schema_not_like (if provided). The information_schema is always
+excluded as it is not droppable in snowflake. 
+
+Args:
+    - database: string        -- the name of the database to clean. By default the target.database is used
+    - dry_run: bool           -- dry run flag. When dry_run is true, the cleanup commands are printed to stdout rather than executed. This is true by default
+    - schema_like: string     -- case-insensitive like pattern of schema names to include. This is None by default. 
+    - schema_not_like: string -- case-insensitive like pattern of schema names to exclude. This is None by default 
+
+Example 1 - dry run of current database
+    dbt run-operation clean_workspace    
+    
+Example 2 - full clean :)
+    dbt run-operation clean_workspace --args '{dry_run: False}'
+#}
+
+{% macro clean_workspace(database=target.database, dry_run=True, schema_like=None, schema_not_like=None) %}
+    {# no-op if not executing #}
+    {% if not execute %}
+        {{ return('') }}
+    {% endif %}
+
+    {%- set msg -%}
+        Starting clean_workspace...
+          - database:        {{database}} 
+          - dry_run:         {{dry_run}} 
+          - schema_like:     {{schema_like}} 
+          - schema_not_like: {{schema_not_like}} 
+    {%- endset -%}
+    {{ log(msg, info=True) }}
+
+
+    {% set get_drop_commands_query %}
+        SELECT
+            'DROP SCHEMA {{database}}.' || SCHEMA_NAME || '{{' cascade' if 'databricks' in target.type else ''}}' AS DROP_QUERY
+        FROM
+            {{database}}.INFORMATION_SCHEMA.SCHEMATA
+        WHERE
+            lower(SCHEMA_NAME) != 'information_schema'
+        {%- if schema_like -%}
+            AND SCHEMA_NAME ILIKE '{{schema_like}}' 
+        {%- endif -%}
+        {%- if schema_not_like -%}
+            AND NOT SCHEMA_NAME ILIKE '{{schema_not_like}}' 
+        {%- endif -%}
+    {% endset %}
+
+
+    {# generate drop queries #}
+    {% set drop_queries = run_query(get_drop_commands_query).columns[0].values() %}
+
+
+    {# It's business time! Get to dropping #}
+    {% do log('dropping (dry_run= ' ~ dry_run ~ '):', True) %}
+    {% for drop_query in drop_queries %}
+        {{ log('\t- ' ~ drop_query, info=True) }}
+        {% if not dry_run %}
+            {% do run_query(drop_query) %}
+        {% endif %}
+    {% endfor %}
+{% endmacro %}

--- a/macros/utils/drop_ci_schemas.sql
+++ b/macros/utils/drop_ci_schemas.sql
@@ -1,0 +1,50 @@
+{# drop_ci_schemas
+
+This macro drops the schemas provided as a list of strings in the schemas_to_drop, but only for CI builds.
+
+The current target.name is used to determine if this is a CI build or not.
+
+Args:
+    - schemas_to_drop: list[string] -- the name of the database to clean.
+    - dry_run: bool -- When dry_run is true, the commands are logged rather than executed. This is true by default
+
+
+Example 1 - dry run of a list of schemas
+    dbt run-operation drop_ci_schemas --args '{schemas_to_drop: ["schema_a", "schema_b"], target_name_override: "ci"}'
+    
+Example 2 - live run in an on-run-end hook to drop any schema dbt created in the current run
+    dbt run-operation clean_workspace --args '{database: my_database, dry_run: False, schema_like: "cool_schema_%" }'
+#}
+
+{% macro drop_ci_schemas(schemas_to_drop, dry_run=True, target_name_override=None) %}
+    {# use the target_name_override if it exists #}
+    {% set target_name = target_name_override if target_name_override else target.name.lower() %}
+
+    {# no-op if not executing OR if this isn't a ci/test build #}
+    {% if not execute or not ('ci' in target_name or 'test' in target_name) %}
+        {{ return('') }}
+    {% endif %}
+
+    {# quick log of args #}
+    {% do log('drop_ci_schemas:', True) %}
+    {% do log('\t- schemas_to_drop: ' ~ schemas_to_drop, True) %}
+    {% do log('\t- dry_run: ' ~ dry_run, True) %}
+    {% do log('\t- target_name_override: ' ~ target_name_override, True) %}
+    {% do log('\t- target_name: ' ~ target_name, True) %}
+    {% do log('\n', True) %}
+
+    {# game time! Let's drop some schemas #}
+    {% do log('dropping (dry_run= ' ~ dry_run ~ '):', True) %}
+    {% for schema in schemas_to_drop %}
+        {%- set drop_sql -%}
+           drop schema {{schema}} {{ 'cascade' if 'databricks' in target.type else ''}};
+        {%- endset -%}
+
+        {% do log('\t- ' ~ drop_sql, True) %}
+
+        {% if not dry_run %}
+            {% do run_query(drop_sql) %}    
+        {% endif %}
+    {% endfor %}
+    {% do log('\n', True) %}
+{% endmacro %}

--- a/macros/utils/drop_ci_schemas.sql
+++ b/macros/utils/drop_ci_schemas.sql
@@ -9,11 +9,11 @@ Args:
     - dry_run: bool -- When dry_run is true, the commands are logged rather than executed. This is true by default
 
 
-Example 1 - dry run of a list of schemas
+Example 1 - dry run of a list of schemas in a run operation using the override to force the macro to execute
     dbt run-operation drop_ci_schemas --args '{schemas_to_drop: ["schema_a", "schema_b"], target_name_override: "ci"}'
     
-Example 2 - live run in an on-run-end hook to drop any schema dbt created in the current run
-    dbt run-operation clean_workspace --args '{database: my_database, dry_run: False, schema_like: "cool_schema_%" }'
+Example 2 - live run in an on-run-end hook to drop any schema dbt created in the current run (unless running outside a ci target)
+    on-run-end: "{{ drop_ci_schemas(schemas, dry_run=False) }}"
 #}
 
 {% macro drop_ci_schemas(schemas_to_drop, dry_run=True, target_name_override=None) %}


### PR DESCRIPTION
- simplified `generate_schema_name` logic so ci/test/dev builds all just use the target.schema
- added a macro to drop PR schemas on-run-end, regardless of what dbt cloud will/won't do for cleanup
- added a clean_workspace macro that works across snowflake and databricks. Great for scheduling run operations