### PR TITLE
Feature/transition off of target.name

### DIFF
--- a/macros/config/generate_schema_name.sql
+++ b/macros/config/generate_schema_name.sql
@@ -1,15 +1,16 @@
 {%- macro generate_schema_name(custom_schema_name, node) -%}
-    {% set default_schema = env_var('DBT_DEFAULT_SCHEMA') %}
+    {% set current_environment = env_var('DBT_ENVIRONMENT_NAME') %}
+    {% set default_schema      = env_var('DBT_DEFAULT_SCHEMA') %}
 
-    {% if target.name == 'default' or 'ci' in target.name.lower() or 'test' in target.name.lower() %}
+    {% if current_environment == 'default' or 'ci' in current_environment.lower() or 'test' in current_environment.lower() %}
         {{target.schema}}
 
-    {% elif 'production' in target.name %}
+    {% elif 'production' in current_environment %}
         {{ custom_schema_name if custom_schema_name else default_schema }}
         
     {% else %}
         {%- set err_msg -%}
-            Unrecognized target.name provided - Got: {{target.name}}
+            Unrecognized current_environment provided - Got: {{current_environment}}
                 node.identifier: {{node.identifier}}
                 custom_schema_name: {{custom_schema_name}}
                 node: {{node}}

--- a/models/retail/marts/monthly_gross_revenue.sql
+++ b/models/retail/marts/monthly_gross_revenue.sql
@@ -1,12 +1,12 @@
 
 select
-    order_month,
+    order_month, nation, region,
     sum(gross_revenue) as gross_revenue
 
 from {{ref('order_details')}}
 
-group by order_month
-order by order_month desc
+group by order_month, nation, region
+order by order_month desc, gross_revenue desc
 
 
 

--- a/models/retail/marts/monthly_gross_revenue.sql
+++ b/models/retail/marts/monthly_gross_revenue.sql
@@ -1,12 +1,12 @@
 
 select
-    order_month, nation, region,
+    order_month,
     sum(gross_revenue) as gross_revenue
 
 from {{ref('order_details')}}
 
-group by order_month, nation, region
-order by order_month desc, gross_revenue desc
+group by order_month
+order by order_month desc
 
 
 


### PR DESCRIPTION
- added a new environment variable in dbt cloud `DBT_ENVIRONMENT_NAME` to replace target.name due to bug in semantic layer that sets target.name=default at all times, which screws up generate_x_name macro overrides
- updated generate_schema_name to use `DBT_ENVIRONMENT_NAME` instead of target.name