### PR TITLE
update used gh actions ahead of node12 deprecation

### DIFF
--- a/.github/workflows/deploy_on_merge.yml
+++ b/.github/workflows/deploy_on_merge.yml
@@ -21,9 +21,9 @@ jobs:
       DBT_PR_JOB_ID:           142617
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.8
     - name: Install dependencies


### PR DESCRIPTION
Please merge this update today! [node 12 support dropping tomorrow](https://github.blog/changelog/2023-05-04-github-actions-all-actions-will-run-on-node16-instead-of-node12/) and these version updates to Github Actions get ahead of that. Resolves RELENG-144